### PR TITLE
Added long support

### DIFF
--- a/grails-app/taglib/org/grails/prettytime/PrettyTimeTagLib.groovy
+++ b/grails-app/taglib/org/grails/prettytime/PrettyTimeTagLib.groovy
@@ -17,6 +17,9 @@ class PrettyTimeTagLib {
         if ('org.joda.time.DateTime'.equals(date?.class?.name)) {
             date = date.toDate()
         }
+        else if ('java.lang.Long'.equals(date?.class?.name)) {
+            date = new Date(date)
+        }
 
         if (!date) return
 

--- a/test/unit/org/grails/prettytime/PrettyTimeTagLibTests.groovy
+++ b/test/unit/org/grails/prettytime/PrettyTimeTagLibTests.groovy
@@ -36,6 +36,14 @@ class PrettyTimeTagLibTests {
         assert applyTemplate('<prettytime:display date="${date}" />', [date: dt]) == '2 weeks ago'
 
     }
+	
+	void testFormatDateWithLong() {
+		[new Date(), new Date() - 7, new Date() - 14].each { dateToTest ->
+			assert applyTemplate('<prettytime:display date="${date}" />', [date: dateToTest]) == 
+				applyTemplate('<prettytime:display date="${date}" />', [date: dateToTest.getTime()])
+		}
+	}
+	
 
     void testWithDifferentLocale() {
 


### PR DESCRIPTION
Long is what most date libraries uses under the hook, so I believe it would be handy to have support for it.
