### PR TITLE
The compile version on the readme is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin allows you to display human readable, relative timestamps. It is bas
 ## Installation
 
 ```
-compile ":pretty-time:2.1.3.Final-1.1.0"
+compile ":pretty-time:2.1.3.Final-1.0.1"
 ```
 
 ## Requirements


### PR DESCRIPTION
I had a 5 minutes headache because the plugin was not installing. I realized then the version here and the one on the grails website was different.
